### PR TITLE
moved echo from str() to unicode() so it doesn't break on unicode 

### DIFF
--- a/clip.py
+++ b/clip.py
@@ -18,6 +18,7 @@ PY2 = sys.version_info[0] == 2
 
 input = raw_input if PY2 else input
 text_type = basestring if PY2 else str
+to_str = unicode if PY2 else str
 def is_func(e):
 	return hasattr(e, '__call__')
 def iteritems(d):
@@ -67,7 +68,7 @@ class ClipGlobals(object):
 		self._streams = {}
 
 	def _write(self, message, stream, nl=True):
-		stream.write(unicode(message) + ("\n" if nl else ""))
+		stream.write(to_str(message) + ("\n" if nl else ""))
 		# Custom streams may not implement a flush() method
 		if hasattr(stream, 'flush'):
 			stream.flush()

--- a/clip.py
+++ b/clip.py
@@ -67,7 +67,7 @@ class ClipGlobals(object):
 		self._streams = {}
 
 	def _write(self, message, stream, nl=True):
-		stream.write(str(message) + ("\n" if nl else ""))
+		stream.write(unicode(message) + ("\n" if nl else ""))
 		# Custom streams may not implement a flush() method
 		if hasattr(stream, 'flush'):
 			stream.flush()


### PR DESCRIPTION
clip.echo currently gives an ugly exception when passed a unicode string.  This fixes that.

    >>> import clip
    >>> APP = clip.App()
    >>> clip.echo(u'\u0131 5+1 \xc7evre')
    Traceback (most recent call last):
      File "<stdin>", line 1, in <module>
      File "/usr/local/lib/python2.7/dist-packages/clip.py", line 105, in echo
        clip_globals.echo(message, err, nl, app)
      File "/usr/local/lib/python2.7/dist-packages/clip.py", line 83, in echo
        self._broadcast(message, err, nl)
      File "/usr/local/lib/python2.7/dist-packages/clip.py", line 77, in _broadcast
        self._write(message, v['err' if err else 'out'], nl)
      File "/usr/local/lib/python2.7/dist-packages/clip.py", line 70, in _write
        stream.write(str(message) + ("\n" if nl else ""))
    UnicodeEncodeError: 'ascii' codec can't encode character u'\u0131' in position 0: ordinal not in range(128)
