### PR TITLE
docs: fix simple typo, occuring -> occurring

### DIFF
--- a/docs/utilities.md
+++ b/docs/utilities.md
@@ -27,7 +27,7 @@ def f():
 ### Parameters
 
 - `message=None`: An optional message to print before exiting. Note that this message is also passed onward to the underlying `ClipExit`.
-- `err=False`: Whether this exit is occuring because of an error.
+- `err=False`: Whether this exit is occurring because of an error.
 
 ## Confirmation Prompt
 


### PR DESCRIPTION
There is a small typo in docs/utilities.md.

Should read `occurring` rather than `occuring`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md